### PR TITLE
Bugfix: Delete onboarding DG2 photos on error

### DIFF
--- a/onboarding-feature/src/main/java/eu/europa/ec/onboardingfeature/ui/passport/passportlivevideo/PassportLiveVideoViewModel.kt
+++ b/onboarding-feature/src/main/java/eu/europa/ec/onboardingfeature/ui/passport/passportlivevideo/PassportLiveVideoViewModel.kt
@@ -91,8 +91,9 @@ class PassportLiveVideoViewModel(
 
     override fun handleEvents(event: Event) {
         when (event) {
-            Event.OnBackPressed -> setEffect {
-                Effect.Navigation.GoBack
+            Event.OnBackPressed -> {
+                viewState.value.config?.faceImageTempPath?.let { deleteTempFile(it) }
+                setEffect { Effect.Navigation.GoBack }
             }
 
             Event.OnLiveVideoCapture -> {
@@ -180,12 +181,14 @@ class PassportLiveVideoViewModel(
                     is FaceMatchPartialState.Failure -> {
                         logController.e(TAG) { "Face match failed: ${matchResult.error}" }
                         setState { copy(isLoading = false) }
+                        deleteTempFile(config.faceImageTempPath)
                         showError(matchResult.error)
                     }
                 }
             } catch (e: Exception) {
                 logController.e(TAG, e) { "Exception during live video capture" }
                 setState { copy(isLoading = false) }
+                deleteTempFile(config.faceImageTempPath)
                 showError(e.message ?: "An unexpected error occurred")
             }
         }


### PR DESCRIPTION
# Description of changes
Current implementation of the onboarding flow deletes the DG2 photo on a successful match, but seemingly persists it on failure. There seems to be no reason to keep the photo when an error occurs (it looks like it'd be fetched again either way), so let's always delete it.

Same if the user backs out of the flow - though I imagine this edge case is unlikely to occur, if there is a temporary file there, let's delete it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test suite run successfully

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable