### PR TITLE
Fix PIN timing side-channel and remove plaintext PIN exposure

### DIFF
--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/controller/storage/PinStorageController.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/controller/storage/PinStorageController.kt
@@ -26,7 +26,7 @@ sealed class PinValidationResult {
 }
 
 interface PinStorageController {
-    fun retrievePin(): String
+    fun hasPin(): Boolean
     fun setPin(pin: String)
     fun isPinValid(pin: String): PinValidationResult
 }
@@ -40,7 +40,7 @@ class PinStorageControllerImpl(private val storageConfig: StorageConfig) : PinSt
 
     private val pinStorageProvider = storageConfig.pinStorageProvider
 
-    override fun retrievePin(): String = pinStorageProvider.retrievePin()
+    override fun hasPin(): Boolean = pinStorageProvider.hasPin()
 
     override fun setPin(pin: String) {
         pinStorageProvider.setPin(pin)

--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/provider/PinStorageProvider.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/provider/PinStorageProvider.kt
@@ -17,7 +17,7 @@
 package eu.europa.ec.authenticationlogic.provider
 
 interface PinStorageProvider {
-    fun retrievePin(): String
+    fun hasPin(): Boolean
     fun setPin(pin: String)
     fun isPinValid(pin: String): Boolean
 

--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/storage/PrefsPinStorageProvider.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/storage/PrefsPinStorageProvider.kt
@@ -21,6 +21,7 @@ import eu.europa.ec.businesslogic.controller.crypto.CryptoController
 import eu.europa.ec.businesslogic.controller.storage.PrefsController
 import eu.europa.ec.businesslogic.extension.decodeFromBase64
 import eu.europa.ec.businesslogic.extension.encodeToBase64String
+import java.security.MessageDigest
 
 class PrefsPinStorageProvider(
     private val prefsController: PrefsController,
@@ -34,11 +35,11 @@ class PrefsPinStorageProvider(
     }
 
     /**
-     * Retrieves the stored PIN after decrypting it.
+     * Checks whether a PIN has been stored.
      *
-     * @return The decrypted PIN as a String. Returns an empty string if no PIN is stored or if decryption fails.
+     * @return True if a non-blank PIN is stored, false otherwise.
      */
-    override fun retrievePin(): String = decryptedAndLoad()
+    override fun hasPin(): Boolean = decryptedAndLoad().isNotBlank()
 
     /**
      * Stores the given PIN in an encrypted format.
@@ -54,12 +55,20 @@ class PrefsPinStorageProvider(
     }
 
     /**
-     * Checks if the provided PIN is valid.
+     * Checks if the provided PIN is valid using constant-time comparison
+     * to prevent timing side-channel attacks.
      *
      * @param pin The PIN to validate.
      * @return True if the provided PIN matches the stored PIN, false otherwise.
      */
-    override fun isPinValid(pin: String): Boolean = retrievePin() == pin
+    override fun isPinValid(pin: String): Boolean {
+        val stored = decryptedAndLoad().toByteArray(Charsets.UTF_8)
+        try {
+            return MessageDigest.isEqual(stored, pin.toByteArray(Charsets.UTF_8))
+        } finally {
+            stored.fill(0)
+        }
+    }
 
     private fun encryptAndStore(pin: String) {
 

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/interactor/QuickPinInteractor.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/interactor/QuickPinInteractor.kt
@@ -49,7 +49,7 @@ class QuickPinInteractorImpl(
     private val genericErrorMsg
         get() = resourceProvider.genericErrorMessage()
 
-    override fun hasPin(): Boolean = pinStorageController.retrievePin().isNotBlank()
+    override fun hasPin(): Boolean = pinStorageController.hasPin()
 
     override fun setPin(
         newPin: String,

--- a/common-feature/src/test/java/eu/europa/ec/commonfeature/interactor/TestQuickPinInteractor.kt
+++ b/common-feature/src/test/java/eu/europa/ec/commonfeature/interactor/TestQuickPinInteractor.kt
@@ -79,12 +79,12 @@ class TestQuickPinInteractor {
     //region hasPin
 
     // Case 1:
-    // prefKeys.getDevicePin() returns empty String.
+    // pinStorageController.hasPin() returns false.
     @Test
     fun `Given Case 1, When hasPin is called, Then it returns false`() {
         // Given
-        whenever(pinStorageController.retrievePin())
-            .thenReturn(mockedEmptyPin)
+        whenever(pinStorageController.hasPin())
+            .thenReturn(false)
 
         // When
         val actual = interactor.hasPin()
@@ -94,16 +94,16 @@ class TestQuickPinInteractor {
 
         assertEquals(expected, actual)
         verify(pinStorageController, times(1))
-            .retrievePin()
+            .hasPin()
     }
 
     // Case 2:
-    // pinStorageController.retrievePin() returns blank String.
+    // pinStorageController.hasPin() returns false.
     @Test
     fun `Given Case 2, When hasPin is called, Then it returns false`() {
         // Given
-        whenever(pinStorageController.retrievePin())
-            .thenReturn(mockedBlankPin)
+        whenever(pinStorageController.hasPin())
+            .thenReturn(false)
 
         // When
         val actual = interactor.hasPin()
@@ -113,16 +113,16 @@ class TestQuickPinInteractor {
 
         assertEquals(expected, actual)
         verify(pinStorageController, times(1))
-            .retrievePin()
+            .hasPin()
     }
 
     // Case 3:
-    // pinStorageController.retrievePin() returns a valid String.
+    // pinStorageController.hasPin() returns true.
     @Test
     fun `Given Case 3, When hasPin is called, Then it returns true`() {
         // Given
-        whenever(pinStorageController.retrievePin())
-            .thenReturn(mockedPin)
+        whenever(pinStorageController.hasPin())
+            .thenReturn(true)
 
         // When
         val actual = interactor.hasPin()
@@ -132,7 +132,7 @@ class TestQuickPinInteractor {
 
         assertEquals(expected, actual)
         verify(pinStorageController, times(1))
-            .retrievePin()
+            .hasPin()
     }
     //endregion
 


### PR DESCRIPTION
Use MessageDigest.isEqual() for constant-time PIN comparison in isPinValid() with byte array zeroing after use. Replace retrievePin() with hasPin() across PinStorageProvider/PinStorageController interfaces to prevent plaintext PIN leaking to callers.

Fixes #70
