### PR TITLE
fix(security): add FLAG_SECURE to prevent screenshots and screen recording

### DIFF
--- a/passport-scanner/src/main/java/eu/europa/ec/passportscanner/nfc/NFCActivity.kt
+++ b/passport-scanner/src/main/java/eu/europa/ec/passportscanner/nfc/NFCActivity.kt
@@ -24,6 +24,7 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.provider.Settings
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
@@ -53,6 +54,10 @@ class NFCActivity : FragmentActivity(), NFCFragment.NfcFragmentListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
         setContentView(R.layout.activity_nfc)
         val mrz = intent.getStringExtra(ScannerConstants.NFC_MRZ_STRING)
             ?: run {

--- a/passport-scanner/src/main/java/eu/europa/ec/passportscanner/scanner/BaseActivity.kt
+++ b/passport-scanner/src/main/java/eu/europa/ec/passportscanner/scanner/BaseActivity.kt
@@ -17,9 +17,19 @@
  */
 package eu.europa.ec.passportscanner.scanner
 
+import android.os.Bundle
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 
 abstract class BaseActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
+    }
 
     fun hideActionBar() {
         supportActionBar?.hide()

--- a/passport-scanner/src/main/java/kl/open/fmandroid/CameraActivity.kt
+++ b/passport-scanner/src/main/java/kl/open/fmandroid/CameraActivity.kt
@@ -30,6 +30,7 @@ import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.os.Bundle
 import android.util.Size
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
@@ -80,6 +81,10 @@ class CameraActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
         logController.d("CameraActivity") { "onCreate: Starting camera activity" }
 
         previewView = PreviewView(this)

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/container/EudiComponentActivity.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/container/EudiComponentActivity.kt
@@ -18,6 +18,8 @@ package eu.europa.ec.uilogic.container
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
+import android.view.WindowManager
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -51,6 +53,14 @@ open class EudiComponentActivity : FragmentActivity() {
 
     internal var pendingDeepLink: Uri? = null
     internal var pendingIntent: Intent? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
+    }
 
     internal fun cacheDeepLink(intent: Intent?) {
         pendingDeepLink = intent?.data


### PR DESCRIPTION
## Summary

Adds `WindowManager.LayoutParams.FLAG_SECURE` to all activities that display sensitive identity data:

- **`EudiComponentActivity`** — base activity for all Compose screens (PIN entry, biometric auth, credential dashboard, presentation, issuance)
- **`BaseActivity`** — parent of `SmartScannerActivity` (MRZ document scanning)
- **`NFCActivity`** — passport chip reading (displays face image, DOB)
- **`CameraActivity`** — live face capture for liveness detection

## Security Impact

This app is an age verification wallet that displays:
- Identity documents and personal data
- Biometric data (passport face photos, live camera captures)
- Proof-of-age attestations and credentials
- PIN entry screens

Without `FLAG_SECURE`, any screen recording app or malicious application can capture the entire user journey, including all sensitive identity and biometric data. This is a well-understood Android security pattern recommended for any application handling identity or financial data.

**Before:** Screens containing biometric data and credentials are fully capturable via screenshots, screen recording, and the recent apps screen.

**After:** Android's window manager prevents screen capture on all activities, showing a black screen for recording/recent apps.

## Test Plan

- [ ] Verify app launches and functions normally on all flows (onboarding, PIN, document scanning, NFC, presentation)
- [ ] Verify attempting to take a screenshot shows a black screen or is blocked
- [ ] Verify screen recording apps capture a black screen
- [ ] Verify the recent apps overview shows a black/blank thumbnail
- [ ] Verify camera preview still works correctly in CameraActivity (FLAG_SECURE should not affect live preview)