### PR TITLE
fix(security): add SHA-256 integrity check for downloaded ML model

### DIFF
--- a/core-logic/src/demo/java/eu/europa/ec/corelogic/config/WalletCoreConfigImpl.kt
+++ b/core-logic/src/demo/java/eu/europa/ec/corelogic/config/WalletCoreConfigImpl.kt
@@ -111,6 +111,7 @@ internal class WalletCoreConfigImpl(
     override val faceMatchConfig: FaceMatchConfig = FaceMatchConfig(
         faceDetectorModel = "mediapipe_long.onnx",
         embeddingExtractorModel = "https://github.com/eu-digital-identity-wallet/av-app-android-wallet-ui/releases/download/2025.10-2/glintr100.onnx",
+        embeddingExtractorModelSha256 = "a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60",
         livenessModel0 = "silentface40.onnx",
         livenessModel1 = "silentface27.onnx",
         livenessThreshold = 0.972017,

--- a/core-logic/src/dev/java/eu/europa/ec/corelogic/config/WalletCoreConfigImpl.kt
+++ b/core-logic/src/dev/java/eu/europa/ec/corelogic/config/WalletCoreConfigImpl.kt
@@ -104,6 +104,7 @@ internal class WalletCoreConfigImpl(
     override val faceMatchConfig: FaceMatchConfig = FaceMatchConfig(
         faceDetectorModel = "mediapipe_long.onnx",
         embeddingExtractorModel = "https://github.com/eu-digital-identity-wallet/av-app-android-wallet-ui/releases/download/2025.10-2/glintr100.onnx",
+        embeddingExtractorModelSha256 = "a7933ea5330113b01c9b60351d8f4c33003f145d8470ac5f0e52ee2effe25c60",
         livenessModel0 = "silentface40.onnx",
         livenessModel1 = "silentface27.onnx",
         livenessThreshold = 0.972017,

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/config/WalletCoreConfig.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/config/WalletCoreConfig.kt
@@ -30,6 +30,7 @@ import java.time.Duration
 data class FaceMatchConfig(
     val faceDetectorModel: String,
     val embeddingExtractorModel: String,
+    val embeddingExtractorModelSha256: String? = null,
     val livenessModel0: String,
     val livenessModel1: String,
     val livenessThreshold: Double,

--- a/onboarding-feature/src/main/java/eu/europa/ec/onboardingfeature/controller/FaceMatchController.kt
+++ b/onboarding-feature/src/main/java/eu/europa/ec/onboardingfeature/controller/FaceMatchController.kt
@@ -64,6 +64,7 @@ class FaceMatchControllerImpl(
         return FaceMatchConfig(
             faceDetectorModel = coreConfig.faceDetectorModel,
             embeddingExtractorModel = coreConfig.embeddingExtractorModel,
+            embeddingExtractorModelSha256 = coreConfig.embeddingExtractorModelSha256,
             livenessModel0 = coreConfig.livenessModel0,
             livenessModel1 = coreConfig.livenessModel1,
             livenessThreshold = coreConfig.livenessThreshold,

--- a/passport-scanner/src/main/java/eu/europa/ec/passportscanner/face/AVFaceMatchSDK.kt
+++ b/passport-scanner/src/main/java/eu/europa/ec/passportscanner/face/AVFaceMatchSDK.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.Flow
 data class FaceMatchConfig(
     val faceDetectorModel: String,
     val embeddingExtractorModel: String,
+    val embeddingExtractorModelSha256: String? = null,
     val livenessModel0: String,
     val livenessModel1: String,
     val livenessThreshold: Double,

--- a/passport-scanner/src/main/java/eu/europa/ec/passportscanner/face/AVFaceMatchSdkImpl.kt
+++ b/passport-scanner/src/main/java/eu/europa/ec/passportscanner/face/AVFaceMatchSdkImpl.kt
@@ -125,7 +125,8 @@ class AVFaceMatchSdkImpl(
                     modelDownloader.prepareModel(
                         config.embeddingExtractorModel,
                         modelBasePath,
-                        embeddingOutputFilename
+                        embeddingOutputFilename,
+                        config.embeddingExtractorModelSha256
                     ) { progress ->
                         _initStatus.value = SdkInitStatus.Preparing(progress)
                     }

--- a/passport-scanner/src/main/java/eu/europa/ec/passportscanner/face/ModelDownloader.kt
+++ b/passport-scanner/src/main/java/eu/europa/ec/passportscanner/face/ModelDownloader.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
+import java.security.MessageDigest
 
 /**
  * Handles downloading and preparing model files for face matching SDK
@@ -44,6 +45,7 @@ class ModelDownloader(
      * @param urlString URL to download from
      * @param destDir Destination directory path
      * @param outputFilename Optional custom filename for the downloaded file. If null, extracts from URL
+     * @param expectedSha256 Optional expected SHA-256 hash (hex) for integrity verification
      * @param onProgress Optional callback for download progress (percentage: 0-100)
      * @return The local filename of the downloaded file, or null if failed
      */
@@ -51,6 +53,7 @@ class ModelDownloader(
         urlString: String,
         destDir: String,
         outputFilename: String? = null,
+        expectedSha256: String? = null,
         onProgress: ((Int) -> Unit)? = null,
     ): String? = withContext(Dispatchers.IO) {
         logController.d(TAG) { "downloadModelFromUrl: Starting download from $urlString" }
@@ -126,6 +129,20 @@ class ModelDownloader(
 
                 tempFile.renameTo(destFile)
                 logController.d(TAG) { "downloadModelFromUrl: Download complete: ${destFile.length()} bytes" }
+
+                if (expectedSha256 != null) {
+                    val actualHash = computeSha256(destFile)
+                    if (!actualHash.equals(expectedSha256, ignoreCase = true)) {
+                        logController.e(TAG) {
+                            "downloadModelFromUrl: SHA-256 integrity check FAILED. " +
+                                    "Expected: $expectedSha256, Got: $actualHash"
+                        }
+                        destFile.delete()
+                        return@withContext null
+                    }
+                    logController.d(TAG) { "downloadModelFromUrl: SHA-256 integrity check passed" }
+                }
+
                 filename
             } else {
                 logController.e(TAG) { "downloadModelFromUrl: HTTP error code: $responseCode" }
@@ -139,6 +156,18 @@ class ModelDownloader(
             // Clean up temp file if it wasn't successfully renamed
             tempFile.delete()
         }
+    }
+
+    private fun computeSha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(8192)
+            var bytesRead: Int
+            while (input.read(buffer).also { bytesRead = it } != -1) {
+                digest.update(buffer, 0, bytesRead)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
     /**
@@ -169,6 +198,7 @@ class ModelDownloader(
      * @param modelPath Either an asset filename or HTTP(S) URL
      * @param destDir Destination directory path
      * @param outputFilename Optional custom filename for downloaded files. Only used for URLs
+     * @param expectedSha256 Optional expected SHA-256 hash (hex) for integrity verification
      * @param onProgress Optional callback for download progress (percentage: 0-100)
      * @return The local filename, or null if preparation failed
      */
@@ -176,12 +206,13 @@ class ModelDownloader(
         modelPath: String,
         destDir: String,
         outputFilename: String? = null,
+        expectedSha256: String? = null,
         onProgress: ((Int) -> Unit)? = null,
     ): String? {
         if (modelPath.isEmpty()) return null
 
         return if (modelPath.startsWith("https://")) {
-            downloadModelFromUrl(modelPath, destDir, outputFilename, onProgress)
+            downloadModelFromUrl(modelPath, destDir, outputFilename, expectedSha256, onProgress)
         } else if (modelPath.startsWith("http://")) {
             logController.e(TAG) { "Rejecting insecure HTTP URL for model download: $modelPath" }
             null

--- a/passport-scanner/src/main/java/eu/europa/ec/passportscanner/face/ModelDownloader.kt
+++ b/passport-scanner/src/main/java/eu/europa/ec/passportscanner/face/ModelDownloader.kt
@@ -132,12 +132,17 @@ class ModelDownloader(
 
                 if (expectedSha256 != null) {
                     val actualHash = computeSha256(destFile)
-                    if (!actualHash.equals(expectedSha256, ignoreCase = true)) {
+                    if (actualHash.uppercase() != expectedSha256.uppercase()) {
                         logController.e(TAG) {
                             "downloadModelFromUrl: SHA-256 integrity check FAILED. " +
                                     "Expected: $expectedSha256, Got: $actualHash"
                         }
-                        destFile.delete()
+                        val deleted = destFile.delete()
+                        if (!deleted) {
+                            logController.w(TAG) {
+                                "downloadModelFromUrl: Failed to delete corrupted file"
+                            }
+                        }
                         return@withContext null
                     }
                     logController.d(TAG) { "downloadModelFromUrl: SHA-256 integrity check passed" }


### PR DESCRIPTION
## Summary

- Adds SHA-256 integrity verification for the face embedding model (`glintr100.onnx`) downloaded at runtime from GitHub Releases
- The expected hash is hardcoded in the build config (part of the signed APK), protecting against supply chain attacks
- On hash mismatch, the downloaded file is deleted and SDK initialization fails

## Security Impact

The face embedding model is a ~349MB ONNX file downloaded from:
```
https://github.com/eu-digital-identity-wallet/av-app-android-wallet-ui/releases/download/2025.10-2/glintr100.onnx
```

This model performs **liveness detection** and **face matching** during passport verification — a security-critical function. Without integrity verification:

- A MITM attacker could substitute a model that always reports `liveness=true` and `face_match=true`
- A compromised CDN or GitHub release could serve a tampered model
- The entire face verification step would be silently bypassed

**After this fix:** Any tampering with the model file is detected and the initialization fails before any face matching operations can occur.

## Implementation Details

- Added optional `expectedSha256` parameter to `FaceMatchConfig` (both in `core-logic` and `passport-scanner`)
- Added `expectedSha256` parameter to `ModelDownloader.downloadModelFromUrl()` and `prepareModel()` — backward compatible, defaults to `null` (no check)
- Hash computation uses `java.security.MessageDigest` with 8KB buffer streaming (no full file load into memory)
- Hash is threaded through `AVFaceMatchSdkImpl` → `ModelDownloader` for the embedding model download
- Asset-based models (liveness, face detector) are not checked — they're bundled in the APK

## Test Plan

- [ ] Verify SDK initialization succeeds with correct model (hash matches)
- [ ] Verify SDK initialization fails if model file is tampered (change a byte, verify failure)
- [ ] Verify existing cached model (already downloaded) still works
- [ ] Verify face matching flow still completes successfully end-to-end