### PR TITLE
build: enable R8 full mode for stronger code optimization and obfuscation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ org.gradle.jvmargs=-Xmx8192m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.enableR8.fullMode=false
+android.enableR8.fullMode=true
 toolChainResolverVersion=1.0.0


### PR DESCRIPTION
## Summary

Changes `android.enableR8.fullMode` from `false` to `true` in `gradle.properties`.

## Why

R8 full mode was explicitly disabled, which significantly weakens the release build's code protection. Full mode enables optimization passes that:

- **More aggressive shrinking** — removes unused classes, methods, and fields that compat mode keeps
- **Class merging** — combines classes vertically/horizontally, making the class structure harder to follow
- **Method inlining** — inlines static methods across classes, flattening the call graph
- **Stronger obfuscation** — with fewer forced keep rules, more identifiers can be shortened/renamed

For an identity wallet application that handles:
- Authentication PIN validation logic
- Biometric authentication flows
- NFC passport reading and verification
- Cryptographic key management
- Age verification credential presentation

...stronger obfuscation directly raises the bar for reverse engineering attacks.

## Risk Assessment

The existing `app/proguard-rules.pro` already contains extensive keep rules for:
- Koin dependency injection (lines 153-188)
- Gson serialization models (lines 109-117)
- NFC/JMRTD libraries (lines 145-151)
- Face matching JNI bridge (lines 190-205)
- All ViewModels (lines 170-172)
- Bouncy Castle (line 138)
- Nimbus JWT/JOSE (line 142)

These rules should prevent compatibility issues with R8 full mode. However, **thorough testing of all app flows in a release build is recommended** before merging.

## Test Plan

- [ ] Build release APK (`./gradlew assembleRelease`) — verify no build errors
- [ ] Test PIN creation and validation flow
- [ ] Test passport NFC scanning flow
- [ ] Test credential issuance flow
- [ ] Test credential presentation (QR scan) flow
- [ ] Test biometric authentication
- [ ] Verify Koin dependency injection works (no missing classes)
- [ ] Verify JNI native bridge calls succeed (face matching)